### PR TITLE
Search feature is now case-insensitive

### DIFF
--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -2,7 +2,7 @@ import React from "react";
 import pokemonList from "../pokemon.json";
 import PokeCard from "./PokeCard";
 
-function CardList({searchQuery}) {
+function CardList({ searchQuery }) {
   /**
    * This function sorts pokemons by their ids in ascending order
    */
@@ -24,9 +24,13 @@ function CardList({searchQuery}) {
 
   return (
     <div className="row row-cols-1 row-cols-md-3 mt-3">
-      {sortedPokemonList.filter(pokemon => pokemon.name.includes(searchQuery)).map((pokemon) => (
-        <PokeCard key={pokemon.id} pokemon={pokemon} />
-      ))}
+      {sortedPokemonList
+        .filter((pokemon) =>
+          pokemon.name.toLowerCase().includes(searchQuery.toLowerCase())
+        )
+        .map((pokemon) => (
+          <PokeCard key={pokemon.id} pokemon={pokemon} />
+        ))}
     </div>
   );
 }


### PR DESCRIPTION
This fix is for #44 .

Before, the search feature is case-sensitive. I can't match Charizard and charmander when I put **ch**. I have now fixed this to be case-insensitive.