### PR TITLE
heroku 1-click deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Pokemon react app - https://pokemon-hacktoberfest.vercel.app/
 
+# Heroku 1 click deployment
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
 # How to contribute -
 
 - Check the issues tab and pick an issue

--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "name": "pokemon",
+  "description": "pokemon",
+  "website": "https://github.com/Juggernaut9/pokemon",
+  "buildpacks": [
+    {
+      "url": "mars/create-react-app"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds easy 1-click deployment to Heroku so anyone can deploy a running instance of your app with ease.

[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://dashboard.heroku.com/new?button-url=https%3A%2F%2Fgithub.com%2Fnntin%2Fpokemon&template=https%3A%2F%2Fgithub.com%2Fnntin%2Fpokemon)

1. Hit the deploy link. Optionally give it an app-name.
2. [Go to manage app](https://i.imgur.com/l1JRnSI.png).
3. [Click open app](https://i.imgur.com/26ZpwoV.png).